### PR TITLE
syntax

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,9 @@
 Package: taxonomyCleanr
 Title: A workflow and set of functions to clean taxonomy data using R
 Version: 1.6.2.9000
-Authors@R: 
+Authors@R: c(
     person("Colin", "Smith", email = "csmith.tar@gmail.com", role = c("aut", "cre"), comment = "https://orcid.org/0000-0003-2261-9931"),
-    person(given = "An T.", family = "Nguyen", role = "ctb")
+    person(given = "An T.", family = "Nguyen", role = "ctb"))
 Description:
     Resolves user supplied taxonomy data against a taxonomic authority, retrieves taxonomic 
     serial numbers, updates users data, and creates the taxonomicCoverage metadata element in 


### PR DESCRIPTION
I think someone forgot the c() function when they added the second author's name.  I was getting a Malformed Authors@R field error when I tried to install the package.  Adding the c() function seems to allow me to install it ok now.